### PR TITLE
let the container to be in charge of the layout

### DIFF
--- a/Button.js
+++ b/Button.js
@@ -123,7 +123,6 @@ var styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 8,
     marginBottom: 10,
-    alignSelf: 'stretch',
     justifyContent: 'center',
   },
   textButton: {


### PR DESCRIPTION
When I use several Buttons to layout in a container. I'm in the habit of controlling children's layout by their parent. But I can't set the layout of children Buttons in a container by just setting `alignItems: 'center'`,so I think at least it can't be set by default.

It`s just a small progress not a bug.
